### PR TITLE
Django 2.1 Upgrades and `black` formatting

### DIFF
--- a/piston/authentication.py
+++ b/piston/authentication.py
@@ -1,13 +1,15 @@
 import binascii
+
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import get_callable
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render_to_response
-from django.template import loader, RequestContext
+from django.template import RequestContext, loader
+from django.urls import get_callable
+
 from piston import forms
 
 from . import oauth
@@ -39,12 +41,12 @@ class HttpBasicAuthentication(object):
         some kind of challenge headers and 401 code on it.
     """
 
-    def __init__(self, auth_func=authenticate, realm='API'):
+    def __init__(self, auth_func=authenticate, realm="API"):
         self.auth_func = auth_func
         self.realm = realm
 
     def is_authenticated(self, request):
-        auth_string = request.META.get('HTTP_AUTHORIZATION', None)
+        auth_string = request.META.get("HTTP_AUTHORIZATION", None)
 
         if not auth_string:
             return False
@@ -52,26 +54,28 @@ class HttpBasicAuthentication(object):
         try:
             (authmeth, auth) = auth_string.split(" ", 1)
 
-            if not authmeth.lower() == 'basic':
+            if not authmeth.lower() == "basic":
                 return False
 
-            auth = auth.strip().decode('base64')
-            (username, password) = auth.split(':', 1)
+            auth = auth.strip().decode("base64")
+            (username, password) = auth.split(":", 1)
         except (ValueError, binascii.Error):
             return False
 
-        request.user = self.auth_func(username=username, password=password) or AnonymousUser()
+        request.user = (
+            self.auth_func(username=username, password=password) or AnonymousUser()
+        )
 
         return not request.user in (False, None, AnonymousUser())
 
     def challenge(self, request=None):
         resp = HttpResponse("Authorization Required")
-        resp['WWW-Authenticate'] = 'Basic realm="%s"' % self.realm
+        resp["WWW-Authenticate"] = 'Basic realm="%s"' % self.realm
         resp.status_code = 401
         return resp
 
     def __repr__(self):
-        return '<HTTPBasic: realm=%s>' % self.realm
+        return "<HTTPBasic: realm=%s>" % self.realm
 
 
 class HttpBasicSimple(HttpBasicAuthentication):
@@ -87,22 +91,26 @@ class HttpBasicSimple(HttpBasicAuthentication):
 
 
 def load_data_store():
-    '''Load data store for OAuth Consumers, Tokens, Nonces and Resources'''
-    path = getattr(settings, 'OAUTH_DATA_STORE', 'piston.store.DataStore')
+    """Load data store for OAuth Consumers, Tokens, Nonces and Resources"""
+    path = getattr(settings, "OAUTH_DATA_STORE", "piston.store.DataStore")
 
     # stolen from django.contrib.auth.load_backend
-    i = path.rfind('.')
+    i = path.rfind(".")
     module, attr = path[:i], path[i + 1 :]
 
     try:
         mod = __import__(module, {}, {}, attr)
     except ImportError as e:
-        raise ImproperlyConfigured('Error importing OAuth data store %s: "%s"' % (module, e))
+        raise ImproperlyConfigured(
+            'Error importing OAuth data store %s: "%s"' % (module, e)
+        )
 
     try:
         cls = getattr(mod, attr)
     except AttributeError:
-        raise ImproperlyConfigured('Module %s does not define a "%s" OAuth data store' % (module, attr))
+        raise ImproperlyConfigured(
+            'Module %s does not define a "%s" OAuth data store' % (module, attr)
+        )
 
     return cls
 
@@ -116,21 +124,21 @@ def initialize_server_request(request):
     Shortcut for initialization.
     """
     # c.f. http://www.mail-archive.com/oauth@googlegroups.com/msg01556.html
-    if request.method == 'POST' and request.FILES == {}:
+    if request.method == "POST" and request.FILES == {}:
         params = dict(list(request.REQUEST.items()))
     else:
         params = {}
 
     # Seems that we want to put HTTP_AUTHORIZATION into 'Authorization'
     # for oauth.py to understand. Lovely.
-    request.META['Authorization'] = request.META.get('HTTP_AUTHORIZATION', '')
+    request.META["Authorization"] = request.META.get("HTTP_AUTHORIZATION", "")
 
     oauth_request = oauth.OAuthRequest.from_request(
         request.method,
         request.build_absolute_uri(),
         headers=request.META,
         parameters=params,
-        query_string=request.environ.get('QUERY_STRING', ''),
+        query_string=request.environ.get("QUERY_STRING", ""),
     )
 
     if oauth_request:
@@ -147,10 +155,10 @@ def send_oauth_error(err=None):
     """
     Shortcut for sending an error.
     """
-    response = HttpResponse(err.message.encode('utf-8'))
+    response = HttpResponse(err.message.encode("utf-8"))
     response.status_code = 401
 
-    realm = 'OAuth'
+    realm = "OAuth"
     header = oauth.build_authenticate_header(realm=realm)
 
     for k, v in list(header.items()):
@@ -177,13 +185,15 @@ def oauth_request_token(request):
 def oauth_auth_view(request, token, callback, params):
     form = forms.OAuthAuthenticationForm(
         initial={
-            'oauth_token': token.key,
-            'oauth_callback': token.get_callback_url() or callback,
+            "oauth_token": token.key,
+            "oauth_callback": token.get_callback_url() or callback,
         }
     )
 
     context = dict(form=form, token=token)
-    return render_to_response('piston/authorize_token.html', context, RequestContext(request))
+    return render_to_response(
+        "piston/authorize_token.html", context, RequestContext(request)
+    )
 
 
 @login_required
@@ -206,7 +216,7 @@ def oauth_user_auth(request):
     if request.method == "GET":
         params = oauth_request.get_normalized_parameters()
 
-        oauth_view = getattr(settings, 'OAUTH_AUTH_VIEW', None)
+        oauth_view = getattr(settings, "OAUTH_AUTH_VIEW", None)
         if oauth_view is None:
             return oauth_auth_view(request, token, callback, params)
         else:
@@ -216,12 +226,12 @@ def oauth_user_auth(request):
             form = forms.OAuthAuthenticationForm(request.POST)
             if form.is_valid():
                 token = oauth_server.authorize_token(token, request.user)
-                args = '?' + token.to_string(only_key=True)
+                args = "?" + token.to_string(only_key=True)
             else:
-                args = '?error=%s' % 'Access not granted by user.'
+                args = "?error=%s" % "Access not granted by user."
 
             if not callback:
-                callback = getattr(settings, 'OAUTH_CALLBACK_VIEW')
+                callback = getattr(settings, "OAUTH_CALLBACK_VIEW")
                 return get_callable(callback)(request, token)
 
             response = HttpResponseRedirect(callback + args)
@@ -229,7 +239,7 @@ def oauth_user_auth(request):
         except oauth.OAuthError as err:
             response = send_oauth_error(err)
     else:
-        response = HttpResponse('Action not allowed.')
+        response = HttpResponse("Action not allowed.")
 
     return response
 
@@ -247,7 +257,9 @@ def oauth_access_token(request):
         return send_oauth_error(err)
 
 
-INVALID_PARAMS_RESPONSE = send_oauth_error(oauth.OAuthError('Invalid request parameters.'))
+INVALID_PARAMS_RESPONSE = send_oauth_error(
+    oauth.OAuthError("Invalid request parameters.")
+)
 
 
 class OAuthAuthentication(object):
@@ -255,7 +267,7 @@ class OAuthAuthentication(object):
     OAuth authentication. Based on work by Leah Culver.
     """
 
-    def __init__(self, realm='API'):
+    def __init__(self, realm="API"):
         self.realm = realm
         self.builder = oauth.build_authenticate_header
 
@@ -295,11 +307,13 @@ class OAuthAuthentication(object):
         """
         response = HttpResponse()
         response.status_code = 401
-        realm = 'API'
+        realm = "API"
 
         for k, v in list(self.builder(realm=realm).items()):
             response[k] = v
-        tmpl = loader.render_to_string('oauth/challenge.html', {'MEDIA_URL': settings.MEDIA_URL})
+        tmpl = loader.render_to_string(
+            "oauth/challenge.html", {"MEDIA_URL": settings.MEDIA_URL}
+        )
 
         response.content = tmpl
         return response
@@ -313,8 +327,15 @@ class OAuthAuthentication(object):
         OAuth spec, but otherwise fall back to `GET` and `POST`.
         """
         must_have = [
-            'oauth_' + s
-            for s in ['consumer_key', 'token', 'signature', 'signature_method', 'timestamp', 'nonce']
+            "oauth_" + s
+            for s in [
+                "consumer_key",
+                "token",
+                "signature",
+                "signature_method",
+                "timestamp",
+                "nonce",
+            ]
         ]
 
         is_in = lambda l: all([(p in l) for p in must_have])

--- a/piston/doc.py
+++ b/piston/doc.py
@@ -1,7 +1,9 @@
 import inspect
-from django.core.urlresolvers import get_callable, get_resolver, get_script_prefix
+
 from django.shortcuts import render_to_response
 from django.template import RequestContext
+from django.urls import get_callable, get_resolver, get_script_prefix
+
 from piston.handler import handler_tracker, typemapper
 
 from . import handler
@@ -28,7 +30,7 @@ class HandlerMethod(object):
         args, _, _, defaults = inspect.getargspec(self.method)
 
         for idx, arg in enumerate(args):
-            if arg in ('self', 'request', 'form'):
+            if arg in ("self", "request", "form"):
                 continue
 
             didx = len(args) - idx
@@ -46,9 +48,9 @@ class HandlerMethod(object):
             spec += argn
 
             if argdef:
-                spec += '=%s' % argdef
+                spec += "=%s" % argdef
 
-            spec += ', '
+            spec += ", "
 
         spec = spec.rstrip(", ")
 
@@ -67,14 +69,14 @@ class HandlerMethod(object):
 
     @property
     def http_name(self):
-        if self.name == 'read':
-            return 'GET'
-        elif self.name == 'create':
-            return 'POST'
-        elif self.name == 'delete':
-            return 'DELETE'
-        elif self.name == 'update':
-            return 'PUT'
+        if self.name == "read":
+            return "GET"
+        elif self.name == "create":
+            return "POST"
+        elif self.name == "delete":
+            return "DELETE"
+        elif self.name == "update":
+            return "PUT"
 
     def __repr__(self):
         return "<Method: %s>" % self.name
@@ -91,13 +93,19 @@ class HandlerDocumentation(object):
             if not met:
                 continue
 
-            stale = inspect.getmodule(met.im_func) is not inspect.getmodule(self.handler)
+            stale = inspect.getmodule(met.im_func) is not inspect.getmodule(
+                self.handler
+            )
 
             if not self.handler.is_anonymous:
                 if met and (not stale or include_default):
                     yield HandlerMethod(met, stale)
             else:
-                if not stale or met.__name__ == "read" and 'GET' in self.allowed_methods:
+                if (
+                    not stale
+                    or met.__name__ == "read"
+                    and "GET" in self.allowed_methods
+                ):
                     yield HandlerMethod(met, stale)
 
     def get_all_methods(self):
@@ -108,7 +116,7 @@ class HandlerDocumentation(object):
         return self.handler.is_anonymous
 
     def get_model(self):
-        return getattr(self, 'model', None)
+        return getattr(self, "model", None)
 
     @property
     def has_anonymous(self):
@@ -141,7 +149,7 @@ class HandlerDocumentation(object):
         def _convert(template, params=[]):
             """URI template converter"""
             paths = template % dict([p, "{%s}" % p] for p in params)
-            return u'%s%s' % (get_script_prefix(), paths)
+            return "%s%s" % (get_script_prefix(), paths)
 
         try:
             resource_uri = self.handler.resource_uri()
@@ -172,7 +180,7 @@ class HandlerDocumentation(object):
     resource_uri_template = property(get_resource_uri_template)
 
     def __repr__(self):
-        return u'<Documentation for "%s">' % self.name
+        return '<Documentation for "%s">' % self.name
 
 
 def documentation_view(request):
@@ -193,4 +201,6 @@ def documentation_view(request):
 
     docs.sort(_compare)
 
-    return render_to_response('documentation.html', {'docs': docs}, RequestContext(request))
+    return render_to_response(
+        "documentation.html", {"docs": docs}, RequestContext(request)
+    )

--- a/piston/emitters.py
+++ b/piston/emitters.py
@@ -25,7 +25,7 @@ except NameError:
 
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models import Model, permalink
+from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.http import HttpResponse
 from django.urls import NoReverseMatch, reverse
@@ -44,9 +44,6 @@ try:
     import pickle as pickle
 except ImportError:
     import pickle
-
-# Allow people to change the reverser (default `permalink`).
-reverser = permalink
 
 
 class Emitter(object):
@@ -287,7 +284,7 @@ class Emitter(object):
                     url_id, fields = handler.resource_uri(data)
 
                     try:
-                        ret["resource_uri"] = reverser(lambda: (url_id, fields))()
+                        ret["resource_uri"] = reverse(url_id, fields)
                     except NoReverseMatch as e:
                         pass
 

--- a/piston/emitters.py
+++ b/piston/emitters.py
@@ -1,5 +1,3 @@
-
-
 import copy
 import decimal
 import inspect
@@ -27,10 +25,10 @@ except NameError:
 
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.urlresolvers import NoReverseMatch, reverse
 from django.db.models import Model, permalink
 from django.db.models.query import QuerySet
 from django.http import HttpResponse
+from django.urls import NoReverseMatch, reverse
 from django.utils.encoding import smart_str
 from django.utils.xmlutils import SimplerXMLGenerator
 
@@ -66,7 +64,17 @@ class Emitter(object):
 
     EMITTERS = {}
     RESERVED_FIELDS = set(
-        ['read', 'update', 'create', 'delete', 'model', 'anonymous', 'allowed_methods', 'fields', 'exclude']
+        [
+            "read",
+            "update",
+            "create",
+            "delete",
+            "model",
+            "anonymous",
+            "allowed_methods",
+            "fields",
+            "exclude",
+        ]
     )
 
     def __init__(self, payload, typemapper, handler, fields=(), anonymous=True):
@@ -123,11 +131,13 @@ class Emitter(object):
             elif inspect.isfunction(thing):
                 if not inspect.getargspec(thing)[0]:
                     ret = _any(thing())
-            elif hasattr(thing, '__emittable__'):
+            elif hasattr(thing, "__emittable__"):
                 f = thing.__emittable__
                 if inspect.ismethod(f) and len(inspect.getargspec(f)[0]) == 1:
                     ret = _any(f())
-            elif repr(thing).startswith("<django.db.models.fields.related.RelatedManager"):
+            elif repr(thing).startswith(
+                "<django.db.models.fields.related.RelatedManager"
+            ):
                 ret = _any(thing.all())
             else:
                 ret = smart_str(thing, strings_only=True)
@@ -173,7 +183,7 @@ class Emitter(object):
                     get_fields = set(mapped.fields)
                     exclude_fields = set(mapped.exclude).difference(get_fields)
 
-                    if 'absolute_uri' in get_fields:
+                    if "absolute_uri" in get_fields:
                         get_absolute_uri = True
 
                     if not get_fields:
@@ -184,7 +194,7 @@ class Emitter(object):
                             ]
                         )
 
-                    if hasattr(mapped, 'extra_fields'):
+                    if hasattr(mapped, "extra_fields"):
                         get_fields.update(mapped.extra_fields)
 
                     # sets can be negated.
@@ -204,7 +214,7 @@ class Emitter(object):
 
                 for f in data._meta.local_fields + data._meta.virtual_fields:
                     if (
-                        hasattr(f, 'serialize')
+                        hasattr(f, "serialize")
                         and f.serialize
                         and not any([p in met_fields for p in [f.attname, f.name]])
                     ):
@@ -230,7 +240,7 @@ class Emitter(object):
                         inst = getattr(data, model, None)
 
                         if inst:
-                            if hasattr(inst, 'all'):
+                            if hasattr(inst, "all"):
                                 ret[model] = _related(inst, fields)
                             elif callable(inst):
                                 if len(inspect.getargspec(inst)[0]) == 1:
@@ -253,7 +263,9 @@ class Emitter(object):
                             else:
                                 ret[maybe_field] = _any(maybe)
                         else:
-                            handler_f = getattr(handler or self.handler, maybe_field, None)
+                            handler_f = getattr(
+                                handler or self.handler, maybe_field, None
+                            )
 
                             if handler_f:
                                 ret[maybe_field] = _any(handler_f(data))
@@ -271,24 +283,24 @@ class Emitter(object):
             # resouce uri
             if self.in_typemapper(type(data), self.anonymous):
                 handler = self.in_typemapper(type(data), self.anonymous)
-                if hasattr(handler, 'resource_uri'):
+                if hasattr(handler, "resource_uri"):
                     url_id, fields = handler.resource_uri(data)
 
                     try:
-                        ret['resource_uri'] = reverser(lambda: (url_id, fields))()
+                        ret["resource_uri"] = reverser(lambda: (url_id, fields))()
                     except NoReverseMatch as e:
                         pass
 
-            if hasattr(data, 'get_api_url') and 'resource_uri' not in ret:
+            if hasattr(data, "get_api_url") and "resource_uri" not in ret:
                 try:
-                    ret['resource_uri'] = data.get_api_url()
+                    ret["resource_uri"] = data.get_api_url()
                 except:
                     pass
 
             # absolute uri
-            if hasattr(data, 'get_absolute_url') and get_absolute_uri:
+            if hasattr(data, "get_absolute_url") and get_absolute_uri:
                 try:
-                    ret['absolute_uri'] = data.get_absolute_url()
+                    ret["absolute_uri"] = data.get_absolute_url()
                 except:
                     pass
 
@@ -347,7 +359,7 @@ class Emitter(object):
         raise ValueError("No emitters found for type %s" % format)
 
     @classmethod
-    def register(cls, name, klass, content_type='text/plain'):
+    def register(cls, name, klass, content_type="text/plain"):
         """
         Register an emitter.
 
@@ -397,8 +409,8 @@ class XMLEmitter(Emitter):
         return stream.getvalue()
 
 
-Emitter.register('xml', XMLEmitter, 'text/xml; charset=utf-8')
-Mimer.register(lambda *a: None, ('text/xml',))
+Emitter.register("xml", XMLEmitter, "text/xml; charset=utf-8")
+Mimer.register(lambda *a: None, ("text/xml",))
 
 
 class JSONEmitter(Emitter):
@@ -407,18 +419,20 @@ class JSONEmitter(Emitter):
     """
 
     def render(self, request):
-        cb = request.GET.get('callback', None)
-        seria = json.dumps(self.construct(), cls=DjangoJSONEncoder, ensure_ascii=False, indent=4)
+        cb = request.GET.get("callback", None)
+        seria = json.dumps(
+            self.construct(), cls=DjangoJSONEncoder, ensure_ascii=False, indent=4
+        )
 
         # Callback
         if cb and is_valid_jsonp_callback_value(cb):
-            return '%s(%s)' % (cb, seria)
+            return "%s(%s)" % (cb, seria)
 
         return seria
 
 
-Emitter.register('json', JSONEmitter, 'application/json; charset=utf-8')
-Mimer.register(json.loads, ('application/json',))
+Emitter.register("json", JSONEmitter, "application/json; charset=utf-8")
+Mimer.register(json.loads, ("application/json",))
 
 
 class YAMLEmitter(Emitter):
@@ -432,8 +446,8 @@ class YAMLEmitter(Emitter):
 
 
 if yaml:  # Only register yaml if it was import successfully.
-    Emitter.register('yaml', YAMLEmitter, 'application/x-yaml; charset=utf-8')
-    Mimer.register(lambda s: dict(yaml.load(s)), ('application/x-yaml',))
+    Emitter.register("yaml", YAMLEmitter, "application/x-yaml; charset=utf-8")
+    Mimer.register(lambda s: dict(yaml.load(s)), ("application/x-yaml",))
 
 
 class PickleEmitter(Emitter):
@@ -445,7 +459,7 @@ class PickleEmitter(Emitter):
         return pickle.dumps(self.construct())
 
 
-Emitter.register('pickle', PickleEmitter, 'application/python-pickle')
+Emitter.register("pickle", PickleEmitter, "application/python-pickle")
 
 """
 WARNING: Accepting arbitrary pickled data is a huge security concern.
@@ -464,7 +478,7 @@ class DjangoEmitter(Emitter):
     Emitter for the Django serialized format.
     """
 
-    def render(self, request, format='xml'):
+    def render(self, request, format="xml"):
         if isinstance(self.data, HttpResponse):
             return self.data
         elif isinstance(self.data, (int, str)):
@@ -475,4 +489,4 @@ class DjangoEmitter(Emitter):
         return response
 
 
-Emitter.register('django', DjangoEmitter, 'text/xml; charset=utf-8')
+Emitter.register("django", DjangoEmitter, "text/xml; charset=utf-8")

--- a/piston/models.py
+++ b/piston/models.py
@@ -2,6 +2,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+
 from django.contrib.auth.models import User
 from django.core.mail import mail_admins, send_mail
 from django.db import models
@@ -18,10 +19,10 @@ SECRET_SIZE = 32
 VERIFIER_SIZE = 10
 
 CONSUMER_STATES = (
-    ('pending', 'Pending'),
-    ('accepted', 'Accepted'),
-    ('canceled', 'Canceled'),
-    ('rejected', 'Rejected'),
+    ("pending", "Pending"),
+    ("accepted", "Accepted"),
+    ("canceled", "Canceled"),
+    ("rejected", "Rejected"),
 )
 
 
@@ -31,7 +32,7 @@ def generate_random(length=SECRET_SIZE):
 
 class Nonce(models.Model):
     class Meta:
-        app_label = 'piston'
+        app_label = "piston"
 
     token_key = models.CharField(max_length=KEY_SIZE)
     consumer_key = models.CharField(max_length=KEY_SIZE)
@@ -43,7 +44,7 @@ class Nonce(models.Model):
 
 class Consumer(models.Model):
     class Meta:
-        app_label = 'piston'
+        app_label = "piston"
 
     name = models.CharField(max_length=255)
     description = models.TextField()
@@ -51,8 +52,10 @@ class Consumer(models.Model):
     key = models.CharField(max_length=KEY_SIZE)
     secret = models.CharField(max_length=SECRET_SIZE)
 
-    status = models.CharField(max_length=16, choices=CONSUMER_STATES, default='pending')
-    user = models.ForeignKey(User, null=True, blank=True, related_name='consumers')
+    status = models.CharField(max_length=16, choices=CONSUMER_STATES, default="pending")
+    user = models.ForeignKey(
+        User, null=True, blank=True, related_name="consumers", on_delete=models.CASCADE
+    )
 
     objects = ConsumerManager()
 
@@ -83,11 +86,11 @@ class Consumer(models.Model):
 
 class Token(models.Model):
     class Meta:
-        app_label = 'piston'
+        app_label = "piston"
 
     REQUEST = 1
     ACCESS = 2
-    TOKEN_TYPES = ((REQUEST, 'Request'), (ACCESS, 'Access'))
+    TOKEN_TYPES = ((REQUEST, "Request"), (ACCESS, "Access"))
 
     key = models.CharField(max_length=KEY_SIZE)
     secret = models.CharField(max_length=SECRET_SIZE)
@@ -96,8 +99,10 @@ class Token(models.Model):
     timestamp = models.IntegerField(default=int(time.time()))
     is_approved = models.BooleanField(default=False)
 
-    user = models.ForeignKey(User, null=True, blank=True, related_name='tokens')
-    consumer = models.ForeignKey(Consumer)
+    user = models.ForeignKey(
+        User, null=True, blank=True, related_name="tokens", on_delete=models.CASCADE
+    )
+    consumer = models.ForeignKey(Consumer, on_delete=models.CASCADE)
 
     callback = models.CharField(max_length=255, null=True, blank=True)
     callback_confirmed = models.BooleanField(default=False)
@@ -105,20 +110,24 @@ class Token(models.Model):
     objects = TokenManager()
 
     def __unicode__(self):
-        return "%s Token %s for %s" % (self.get_token_type_display(), self.key, self.consumer)
+        return "%s Token %s for %s" % (
+            self.get_token_type_display(),
+            self.key,
+            self.consumer,
+        )
 
     def to_string(self, only_key=False):
         token_dict = {
-            'oauth_token': self.key,
-            'oauth_token_secret': self.secret,
-            'oauth_callback_confirmed': 'true',
+            "oauth_token": self.key,
+            "oauth_token_secret": self.secret,
+            "oauth_callback_confirmed": "true",
         }
 
         if self.verifier:
-            token_dict.update({'oauth_verifier': self.verifier})
+            token_dict.update({"oauth_verifier": self.verifier})
 
         if only_key:
-            del token_dict['oauth_token_secret']
+            del token_dict["oauth_token_secret"]
 
         return urllib.parse.urlencode(token_dict)
 
@@ -141,10 +150,12 @@ class Token(models.Model):
             parts = urllib.parse.urlparse(self.callback)
             scheme, netloc, path, params, query, fragment = parts[:6]
             if query:
-                query = '%s&oauth_verifier=%s' % (query, self.verifier)
+                query = "%s&oauth_verifier=%s" % (query, self.verifier)
             else:
-                query = 'oauth_verifier=%s' % self.verifier
-            return urllib.parse.urlunparse((scheme, netloc, path, params, query, fragment))
+                query = "oauth_verifier=%s" % self.verifier
+            return urllib.parse.urlunparse(
+                (scheme, netloc, path, params, query, fragment)
+            )
         return self.callback
 
     def set_callback(self, callback):

--- a/piston/resource.py
+++ b/piston/resource.py
@@ -305,6 +305,12 @@ class Resource(object):
             if self.email_errors:
                 self.email_exception(rep)
             if self.display_errors:
-                return HttpResponseServerError(format_error('\n'.join(rep.format_exception())))
+                return HttpResponseServerError(
+                    format_error(
+                        traceback.format_exception(
+                            etype=exc_type, value=exc_value, tb=tb
+                        )
+                    )
+                )
             else:
                 raise

--- a/piston/utils.py
+++ b/piston/utils.py
@@ -5,15 +5,19 @@ from django import get_version as django_version
 from django.conf import settings
 from django.core.cache import cache
 from django.core.mail import mail_admins, send_mail
-from django.core.urlresolvers import reverse
-from django.http import (HttpResponse, HttpResponseBadRequest,
-                         HttpResponseForbidden, HttpResponseNotAllowed)
+from django.http import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseNotAllowed,
+)
 from django.template import TemplateDoesNotExist, loader
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from .decorator import decorator
 
-__version__ = '0.2.3rc1'
+__version__ = "0.2.3rc1"
 
 
 def get_version():
@@ -21,7 +25,11 @@ def get_version():
 
 
 def format_error(error):
-    return "Piston/%s (Django %s) crash report:\n\n%s" % (get_version(), django_version(), error)
+    return "Piston/%s (Django %s) crash report:\n\n%s" % (
+        get_version(),
+        django_version(),
+        error,
+    )
 
 
 class rc_factory(object):
@@ -30,17 +38,17 @@ class rc_factory(object):
     """
 
     CODES = dict(
-        ALL_OK=('OK', 200),
-        CREATED=('Created', 201),
-        DELETED=('', 204),  # 204 says "Don't send a body!"
-        BAD_REQUEST=('Bad Request', 400),
-        FORBIDDEN=('Forbidden', 401),
-        NOT_FOUND=('Not Found', 404),
-        DUPLICATE_ENTRY=('Conflict/Duplicate', 409),
-        NOT_HERE=('Gone', 410),
-        INTERNAL_ERROR=('Internal Error', 500),
-        NOT_IMPLEMENTED=('Not Implemented', 501),
-        THROTTLED=('Throttled', 503),
+        ALL_OK=("OK", 200),
+        CREATED=("Created", 201),
+        DELETED=("", 204),  # 204 says "Don't send a body!"
+        BAD_REQUEST=("Bad Request", 400),
+        FORBIDDEN=("Forbidden", 401),
+        NOT_FOUND=("Not Found", 404),
+        DUPLICATE_ENTRY=("Conflict/Duplicate", 409),
+        NOT_HERE=("Gone", 410),
+        INTERNAL_ERROR=("Internal Error", 500),
+        NOT_IMPLEMENTED=("Not Implemented", 501),
+        THROTTLED=("Throttled", 503),
     )
 
     def __getattr__(self, attr):
@@ -69,7 +77,7 @@ class rc_factory(object):
                 HttpResponse.content although this bug report (feature request)
                 suggests that it should: http://code.djangoproject.com/ticket/9403
                 """
-                if not isinstance(content, str) and hasattr(content, '__iter__'):
+                if not isinstance(content, str) and hasattr(content, "__iter__"):
                     self._container = content
                     self._base_content_is_iter = False
                 else:
@@ -78,7 +86,7 @@ class rc_factory(object):
 
             content = property(HttpResponse.content.getter, _set_content)
 
-        return HttpResponseWrapper(r, content_type='text/plain', status=c)
+        return HttpResponseWrapper(r, content_type="text/plain", status=c)
 
 
 rc = rc_factory()
@@ -94,13 +102,13 @@ class HttpStatusCode(Exception):
         self.response = response
 
 
-def validate(v_form, operation='POST'):
+def validate(v_form, operation="POST"):
     @decorator
     def wrap(f, self, request, *a, **kwa):
         form = v_form(getattr(request, operation))
 
         if form.is_valid():
-            setattr(request, 'form', form)
+            setattr(request, "form", form)
             return f(self, request, *a, **kwa)
         else:
             raise FormValidationError(form)
@@ -108,7 +116,7 @@ def validate(v_form, operation='POST'):
     return wrap
 
 
-def throttle(max_requests, timeout=60 * 60, extra=''):
+def throttle(max_requests, timeout=60 * 60, extra=""):
     """
     Simple throttling decorator, caches
     the amount of requests made in cache.
@@ -127,16 +135,16 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
         if request.user.is_authenticated():
             ident = request.user.username
         else:
-            ident = request.META.get('REMOTE_ADDR', None)
+            ident = request.META.get("REMOTE_ADDR", None)
 
-        if hasattr(request, 'throttle_extra'):
+        if hasattr(request, "throttle_extra"):
             """
             Since we want to be able to throttle on a per-
             application basis, it's important that we realize
             that `throttle_extra` might be set on the request
             object. If so, append the identifier name with it.
             """
-            ident += ':%s' % str(request.throttle_extra)
+            ident += ":%s" % str(request.throttle_extra)
 
         if ident:
             """
@@ -145,7 +153,7 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
             can't use it yet. If someone sees this after it's in
             stable, you can change it here.
             """
-            ident += ':%s' % extra
+            ident += ":%s" % extra
 
             now = time.time()
             count, expiration = cache.get(ident, (1, None))
@@ -156,8 +164,8 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
             if count >= max_requests and expiration > now:
                 t = rc.THROTTLED
                 wait = int(expiration - now)
-                t.content = 'Throttled, wait %d seconds.' % wait
-                t['Retry-After'] = wait
+                t.content = "Throttled, wait %d seconds." % wait
+                t["Retry-After"] = wait
                 return t
 
             cache.set(ident, (count + 1, expiration), (expiration - now))
@@ -188,7 +196,7 @@ def coerce_put_post(request):
         # the first time _load_post_and_files is called (both by wsgi.py and
         # modpython.py). If it's set, the request has to be 'reset' to redo
         # the query value parsing in POST mode.
-        if hasattr(request, '_post'):
+        if hasattr(request, "_post"):
             del request._post
             del request._files
 
@@ -197,9 +205,9 @@ def coerce_put_post(request):
             request._load_post_and_files()
             request.method = "PUT"
         except AttributeError:
-            request.META['REQUEST_METHOD'] = 'POST'
+            request.META["REQUEST_METHOD"] = "POST"
             request._load_post_and_files()
-            request.META['REQUEST_METHOD'] = 'PUT'
+            request.META["REQUEST_METHOD"] = "PUT"
 
         request.PUT = request.POST
 
@@ -222,7 +230,7 @@ class Mimer(object):
         content_type = self.content_type()
 
         if content_type is not None:
-            return content_type.lstrip().startswith('multipart')
+            return content_type.lstrip().startswith("multipart")
 
         return False
 
@@ -243,7 +251,7 @@ class Mimer(object):
         """
         type_formencoded = "application/x-www-form-urlencoded"
 
-        ctype = self.request.META.get('CONTENT_TYPE', type_formencoded)
+        ctype = self.request.META.get("CONTENT_TYPE", type_formencoded)
 
         if type_formencoded in ctype:
             return None
@@ -272,12 +280,12 @@ class Mimer(object):
             if loadee:
                 try:
                     incoming_data = self.request.body
-                    if 'application/json' in ctype and type(incoming_data) is bytes:
+                    if "application/json" in ctype and type(incoming_data) is bytes:
                         # Covers 'application/json' and 'application/json; charset=utf-8' equally
                         # If by some cursed miracle, we're dealing with a bytestring,
                         # then decode it back to a normal string, because json.loads
                         # will *not* handle binary data
-                        incoming_data = incoming_data.decode('utf-8')
+                        incoming_data = incoming_data.decode("utf-8")
 
                     self.request.data = loadee(incoming_data)
 
@@ -318,10 +326,10 @@ def require_mime(*mimes):
         realmimes = set()
 
         rewrite = {
-            'json': 'application/json',
-            'yaml': 'application/x-yaml',
-            'xml': 'text/xml',
-            'pickle': 'application/python-pickle',
+            "json": "application/json",
+            "yaml": "application/x-yaml",
+            "xml": "text/xml",
+            "pickle": "application/python-pickle",
         }
 
         for idx, mime in enumerate(mimes):
@@ -335,7 +343,7 @@ def require_mime(*mimes):
     return wrap
 
 
-require_extended = require_mime('json', 'yaml', 'xml', 'pickle')
+require_extended = require_mime("json", "yaml", "xml", "pickle")
 
 
 def send_consumer_mail(consumer):
@@ -350,7 +358,9 @@ def send_consumer_mail(consumer):
     template = "piston/mails/consumer_%s.txt" % consumer.status
 
     try:
-        body = loader.render_to_string(template, {'consumer': consumer, 'user': consumer.user})
+        body = loader.render_to_string(
+            template, {"consumer": consumer, "user": consumer.user}
+        )
     except TemplateDoesNotExist:
         """
         They haven't set up the templates, which means they might not want
@@ -366,7 +376,7 @@ def send_consumer_mail(consumer):
     if consumer.user:
         send_mail(_(subject), body, sender, [consumer.user.email], fail_silently=True)
 
-    if consumer.status == 'pending' and len(settings.ADMINS):
+    if consumer.status == "pending" and len(settings.ADMINS):
         mail_admins(_(subject), body, fail_silently=True)
 
     if settings.DEBUG and consumer.user:

--- a/tests/test_project/apps/testapp/models.py
+++ b/tests/test_project/apps/testapp/models.py
@@ -1,39 +1,48 @@
 from django.db import models
 
+
 class TestModel(models.Model):
     test1 = models.CharField(max_length=1, blank=True, null=True)
     test2 = models.CharField(max_length=1, blank=True, null=True)
-    
+
+
 class ExpressiveTestModel(models.Model):
     title = models.CharField(max_length=255)
     content = models.TextField()
     never_shown = models.TextField()
-    
+
+
 class Comment(models.Model):
-    parent = models.ForeignKey(ExpressiveTestModel, related_name='comments')
+    parent = models.ForeignKey(
+        ExpressiveTestModel, related_name="comments", on_delete=models.CASCADE
+    )
     content = models.TextField()
 
+
 class AbstractModel(models.Model):
-    some_field = models.CharField(max_length=32, default='something here')
-    
+    some_field = models.CharField(max_length=32, default="something here")
+
     class Meta:
         abstract = True
-        
+
+
 class InheritedModel(AbstractModel):
-    some_other = models.CharField(max_length=32, default='something else')
-    
+    some_other = models.CharField(max_length=32, default="something else")
+
     class Meta:
-        db_table = 'testing_abstracts'
+        db_table = "testing_abstracts"
+
 
 class PlainOldObject(object):
     def __emittable__(self):
-        return {'type': 'plain',
-                'field': 'a field'}
+        return {"type": "plain", "field": "a field"}
+
 
 class ListFieldsModel(models.Model):
     kind = models.CharField(max_length=15)
     variety = models.CharField(max_length=15)
     color = models.CharField(max_length=15)
+
 
 class Issue58Model(models.Model):
     read = models.BooleanField(default=False)


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update Django Piston codebase to support Django 2.1 by migrating deprecated import paths and applying black code formatter for consistent style.

Main changes:
- Migrated deprecated Django imports from `django.core.urlresolvers` to `django.urls` module for Django 2.1 compatibility
- Updated ForeignKey fields to include required `on_delete=models.CASCADE` parameter per Django 2.1 requirements
- Applied black formatter across entire codebase converting single quotes to double quotes and standardizing whitespace

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
