### PR TITLE
fix: replace inspect.getargspec/formatargspec removed in Python 3.12

### DIFF
--- a/piston/decorator.py
+++ b/piston/decorator.py
@@ -11,12 +11,13 @@ for the documentation and below for the licence.
 
 __all__ = ["decorator", "new_wrapper", "getinfo"]
 
-import inspect, sys
+import inspect
 
 try:
     set
 except NameError:
     from sets import Set as set
+
 
 def getinfo(func):
     """
@@ -28,7 +29,7 @@ def getinfo(func):
     - doc (the docstring : str)
     - module (the module name : str)
     - dict (the function __dict__ : str)
-    
+
     >>> def f(self, x=1, y=2, *args, **kw): pass
 
     >>> info = getinfo(f)
@@ -37,7 +38,7 @@ def getinfo(func):
     'f'
     >>> info["argnames"]
     ['self', 'x', 'y', 'args', 'kw']
-    
+
     >>> info["defaults"]
     (1, 2)
 
@@ -45,60 +46,77 @@ def getinfo(func):
     'self, x, y, *args, **kw'
     """
     assert inspect.ismethod(func) or inspect.isfunction(func)
-    regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
+    regargs, varargs, varkwargs, defaults = inspect.getfullargspec(func)[:4]
     argnames = list(regargs)
     if varargs:
         argnames.append(varargs)
     if varkwargs:
         argnames.append(varkwargs)
-    signature = inspect.formatargspec(regargs, varargs, varkwargs, defaults,
-                                      formatvalue=lambda value: "")[1:-1]
-    return dict(name=func.__name__, argnames=argnames, signature=signature,
-                defaults = func.__defaults__, doc=func.__doc__,
-                module=func.__module__, dict=func.__dict__,
-                globals=func.__globals__, closure=func.__closure__)
+    parts = list(regargs)
+    if varargs:
+        parts.append("*" + varargs)
+    if varkwargs:
+        parts.append("**" + varkwargs)
+    signature = ", ".join(parts)
+    return dict(
+        name=func.__name__,
+        argnames=argnames,
+        signature=signature,
+        defaults=func.__defaults__,
+        doc=func.__doc__,
+        module=func.__module__,
+        dict=func.__dict__,
+        globals=func.__globals__,
+        closure=func.__closure__,
+    )
+
 
 # akin to functools.update_wrapper
 def update_wrapper(wrapper, model, infodict=None):
     infodict = infodict or getinfo(model)
     try:
-        wrapper.__name__ = infodict['name']
-    except: # Python version < 2.4
+        wrapper.__name__ = infodict["name"]
+    except:  # Python version < 2.4
         pass
-    wrapper.__doc__ = infodict['doc']
-    wrapper.__module__ = infodict['module']
-    wrapper.__dict__.update(infodict['dict'])
-    wrapper.__defaults__ = infodict['defaults']
+    wrapper.__doc__ = infodict["doc"]
+    wrapper.__module__ = infodict["module"]
+    wrapper.__dict__.update(infodict["dict"])
+    wrapper.__defaults__ = infodict["defaults"]
     wrapper.undecorated = model
     return wrapper
+
 
 def new_wrapper(wrapper, model):
     """
     An improvement over functools.update_wrapper. The wrapper is a generic
-    callable object. It works by generating a copy of the wrapper with the 
+    callable object. It works by generating a copy of the wrapper with the
     right signature and by updating the copy, not the original.
     Moreovoer, 'model' can be a dictionary with keys 'name', 'doc', 'module',
     'dict', 'defaults'.
     """
     if isinstance(model, dict):
         infodict = model
-    else: # assume model is a function
+    else:  # assume model is a function
         infodict = getinfo(model)
-    assert not '_wrapper_' in infodict["argnames"], (
-        '"_wrapper_" is a reserved argument name!')
+    assert "_wrapper_" not in infodict["argnames"], (
+        '"_wrapper_" is a reserved argument name!'
+    )
     src = "lambda %(signature)s: _wrapper_(%(signature)s)" % infodict
     funcopy = eval(src, dict(_wrapper_=wrapper))
     return update_wrapper(funcopy, model, infodict)
 
+
 # helper used in decorator_factory
 def __call__(self, func):
     infodict = getinfo(func)
-    for name in ('_func_', '_self_'):
-        assert not name in infodict["argnames"], (
-           '%s is a reserved argument name!' % name)
+    for name in ("_func_", "_self_"):
+        assert name not in infodict["argnames"], (
+            "%s is a reserved argument name!" % name
+        )
     src = "lambda %(signature)s: _self_.call(_func_, %(signature)s)"
     new = eval(src % infodict, dict(_func_=func, _self_=self))
     return update_wrapper(new, func, infodict)
+
 
 def decorator_factory(cls):
     """
@@ -108,14 +126,13 @@ def decorator_factory(cls):
     method.
     """
     attrs = set(dir(cls))
-    if '__call__' in attrs:
-        raise TypeError('You cannot decorate a class with a nontrivial '
-                        '__call__ method')
-    if 'call' not in attrs:
-        raise TypeError('You cannot decorate a class without a '
-                        '.call method')
+    if "__call__" in attrs:
+        raise TypeError("You cannot decorate a class with a nontrivial __call__ method")
+    if "call" not in attrs:
+        raise TypeError("You cannot decorate a class without a .call method")
     cls.__call__ = __call__
     return cls
+
 
 def decorator(caller):
     """
@@ -126,7 +143,7 @@ def decorator(caller):
      def caller(func, *args, **kw):
          # do something
          return func(*args, **kw)
-    
+
     Here is an example of usage:
 
     >>> @decorator
@@ -136,7 +153,7 @@ def decorator(caller):
 
     >>> chatty.__name__
     'chatty'
-    
+
     >>> @chatty
     ... def f(): pass
     ...
@@ -149,28 +166,34 @@ def decorator(caller):
     """
     if inspect.isclass(caller):
         return decorator_factory(caller)
-    def _decorator(func): # the real meat is here
+
+    def _decorator(func):  # the real meat is here
         infodict = getinfo(func)
-        argnames = infodict['argnames']
-        assert not ('_call_' in argnames or '_func_' in argnames), (
-            'You cannot use _call_ or _func_ as argument names!')
+        argnames = infodict["argnames"]
+        assert not ("_call_" in argnames or "_func_" in argnames), (
+            "You cannot use _call_ or _func_ as argument names!"
+        )
         src = "lambda %(signature)s: _call_(_func_, %(signature)s)" % infodict
         # import sys; print >> sys.stderr, src # for debugging purposes
         dec_func = eval(src, dict(_func_=func, _call_=caller))
         return update_wrapper(dec_func, func, infodict)
+
     return update_wrapper(_decorator, caller)
 
+
 if __name__ == "__main__":
-    import doctest; doctest.testmod()
+    import doctest
+
+    doctest.testmod()
 
 ##########################     LEGALESE    ###############################
-      
-##   Redistributions of source code must retain the above copyright 
+
+##   Redistributions of source code must retain the above copyright
 ##   notice, this list of conditions and the following disclaimer.
 ##   Redistributions in bytecode form must reproduce the above copyright
 ##   notice, this list of conditions and the following disclaimer in
 ##   the documentation and/or other materials provided with the
-##   distribution. 
+##   distribution.
 
 ##   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ##   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/piston/doc.py
+++ b/piston/doc.py
@@ -1,8 +1,10 @@
 import inspect
+
 from django.core.urlresolvers import get_callable, get_resolver, get_script_prefix
 from django.shortcuts import render_to_response
 from django.template import RequestContext
-from piston.handler import handler_tracker, typemapper
+
+from piston.handler import handler_tracker
 
 from . import handler
 
@@ -25,10 +27,10 @@ class HandlerMethod(object):
         self.stale = stale
 
     def iter_args(self):
-        args, _, _, defaults = inspect.getargspec(self.method)
+        args, _, _, defaults = inspect.getfullargspec(self.method)[:4]
 
         for idx, arg in enumerate(args):
-            if arg in ('self', 'request', 'form'):
+            if arg in ("self", "request", "form"):
                 continue
 
             didx = len(args) - idx
@@ -46,9 +48,9 @@ class HandlerMethod(object):
             spec += argn
 
             if argdef:
-                spec += '=%s' % argdef
+                spec += "=%s" % argdef
 
-            spec += ', '
+            spec += ", "
 
         spec = spec.rstrip(", ")
 
@@ -67,14 +69,14 @@ class HandlerMethod(object):
 
     @property
     def http_name(self):
-        if self.name == 'read':
-            return 'GET'
-        elif self.name == 'create':
-            return 'POST'
-        elif self.name == 'delete':
-            return 'DELETE'
-        elif self.name == 'update':
-            return 'PUT'
+        if self.name == "read":
+            return "GET"
+        elif self.name == "create":
+            return "POST"
+        elif self.name == "delete":
+            return "DELETE"
+        elif self.name == "update":
+            return "PUT"
 
     def __repr__(self):
         return "<Method: %s>" % self.name
@@ -91,13 +93,19 @@ class HandlerDocumentation(object):
             if not met:
                 continue
 
-            stale = inspect.getmodule(met.im_func) is not inspect.getmodule(self.handler)
+            stale = inspect.getmodule(met.im_func) is not inspect.getmodule(
+                self.handler
+            )
 
             if not self.handler.is_anonymous:
                 if met and (not stale or include_default):
                     yield HandlerMethod(met, stale)
             else:
-                if not stale or met.__name__ == "read" and 'GET' in self.allowed_methods:
+                if (
+                    not stale
+                    or met.__name__ == "read"
+                    and "GET" in self.allowed_methods
+                ):
                     yield HandlerMethod(met, stale)
 
     def get_all_methods(self):
@@ -108,7 +116,7 @@ class HandlerDocumentation(object):
         return self.handler.is_anonymous
 
     def get_model(self):
-        return getattr(self, 'model', None)
+        return getattr(self, "model", None)
 
     @property
     def has_anonymous(self):
@@ -141,7 +149,7 @@ class HandlerDocumentation(object):
         def _convert(template, params=[]):
             """URI template converter"""
             paths = template % dict([p, "{%s}" % p] for p in params)
-            return u'%s%s' % (get_script_prefix(), paths)
+            return "%s%s" % (get_script_prefix(), paths)
 
         try:
             resource_uri = self.handler.resource_uri()
@@ -172,7 +180,7 @@ class HandlerDocumentation(object):
     resource_uri_template = property(get_resource_uri_template)
 
     def __repr__(self):
-        return u'<Documentation for "%s">' % self.name
+        return '<Documentation for "%s">' % self.name
 
 
 def documentation_view(request):
@@ -193,4 +201,6 @@ def documentation_view(request):
 
     docs.sort(_compare)
 
-    return render_to_response('documentation.html', {'docs': docs}, RequestContext(request))
+    return render_to_response(
+        "documentation.html", {"docs": docs}, RequestContext(request)
+    )

--- a/piston/emitters.py
+++ b/piston/emitters.py
@@ -1,6 +1,3 @@
-
-
-import copy
 import decimal
 import inspect
 import json
@@ -27,7 +24,7 @@ except NameError:
 
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.core.urlresolvers import NoReverseMatch
 from django.db.models import Model, permalink
 from django.db.models.query import QuerySet
 from django.http import HttpResponse
@@ -66,7 +63,17 @@ class Emitter(object):
 
     EMITTERS = {}
     RESERVED_FIELDS = set(
-        ['read', 'update', 'create', 'delete', 'model', 'anonymous', 'allowed_methods', 'fields', 'exclude']
+        [
+            "read",
+            "update",
+            "create",
+            "delete",
+            "model",
+            "anonymous",
+            "allowed_methods",
+            "fields",
+            "exclude",
+        ]
     )
 
     def __init__(self, payload, typemapper, handler, fields=(), anonymous=True):
@@ -121,13 +128,15 @@ class Emitter(object):
             elif isinstance(thing, HttpResponse):
                 raise HttpStatusCode(thing)
             elif inspect.isfunction(thing):
-                if not inspect.getargspec(thing)[0]:
+                if not inspect.getfullargspec(thing)[0]:
                     ret = _any(thing())
-            elif hasattr(thing, '__emittable__'):
+            elif hasattr(thing, "__emittable__"):
                 f = thing.__emittable__
-                if inspect.ismethod(f) and len(inspect.getargspec(f)[0]) == 1:
+                if inspect.ismethod(f) and len(inspect.getfullargspec(f)[0]) == 1:
                     ret = _any(f())
-            elif repr(thing).startswith("<django.db.models.fields.related.RelatedManager"):
+            elif repr(thing).startswith(
+                "<django.db.models.fields.related.RelatedManager"
+            ):
                 ret = _any(thing.all())
             else:
                 ret = smart_str(thing, strings_only=True)
@@ -173,7 +182,7 @@ class Emitter(object):
                     get_fields = set(mapped.fields)
                     exclude_fields = set(mapped.exclude).difference(get_fields)
 
-                    if 'absolute_uri' in get_fields:
+                    if "absolute_uri" in get_fields:
                         get_absolute_uri = True
 
                     if not get_fields:
@@ -184,7 +193,7 @@ class Emitter(object):
                             ]
                         )
 
-                    if hasattr(mapped, 'extra_fields'):
+                    if hasattr(mapped, "extra_fields"):
                         get_fields.update(mapped.extra_fields)
 
                     # sets can be negated.
@@ -204,7 +213,7 @@ class Emitter(object):
 
                 for f in data._meta.local_fields + data._meta.virtual_fields:
                     if (
-                        hasattr(f, 'serialize')
+                        hasattr(f, "serialize")
                         and f.serialize
                         and not any([p in met_fields for p in [f.attname, f.name]])
                     ):
@@ -230,10 +239,10 @@ class Emitter(object):
                         inst = getattr(data, model, None)
 
                         if inst:
-                            if hasattr(inst, 'all'):
+                            if hasattr(inst, "all"):
                                 ret[model] = _related(inst, fields)
                             elif callable(inst):
-                                if len(inspect.getargspec(inst)[0]) == 1:
+                                if len(inspect.getfullargspec(inst)[0]) == 1:
                                     ret[model] = _any(inst(), fields)
                             else:
                                 ret[model] = _model(inst, fields)
@@ -248,12 +257,14 @@ class Emitter(object):
                         maybe = getattr(data, maybe_field, None)
                         if maybe is not None:
                             if callable(maybe):
-                                if len(inspect.getargspec(maybe)[0]) <= 1:
+                                if len(inspect.getfullargspec(maybe)[0]) <= 1:
                                     ret[maybe_field] = _any(maybe())
                             else:
                                 ret[maybe_field] = _any(maybe)
                         else:
-                            handler_f = getattr(handler or self.handler, maybe_field, None)
+                            handler_f = getattr(
+                                handler or self.handler, maybe_field, None
+                            )
 
                             if handler_f:
                                 ret[maybe_field] = _any(handler_f(data))
@@ -271,24 +282,24 @@ class Emitter(object):
             # resouce uri
             if self.in_typemapper(type(data), self.anonymous):
                 handler = self.in_typemapper(type(data), self.anonymous)
-                if hasattr(handler, 'resource_uri'):
+                if hasattr(handler, "resource_uri"):
                     url_id, fields = handler.resource_uri(data)
 
                     try:
-                        ret['resource_uri'] = reverser(lambda: (url_id, fields))()
-                    except NoReverseMatch as e:
+                        ret["resource_uri"] = reverser(lambda: (url_id, fields))()
+                    except NoReverseMatch:
                         pass
 
-            if hasattr(data, 'get_api_url') and 'resource_uri' not in ret:
+            if hasattr(data, "get_api_url") and "resource_uri" not in ret:
                 try:
-                    ret['resource_uri'] = data.get_api_url()
+                    ret["resource_uri"] = data.get_api_url()
                 except:
                     pass
 
             # absolute uri
-            if hasattr(data, 'get_absolute_url') and get_absolute_uri:
+            if hasattr(data, "get_absolute_url") and get_absolute_uri:
                 try:
-                    ret['absolute_uri'] = data.get_absolute_url()
+                    ret["absolute_uri"] = data.get_absolute_url()
                 except:
                     pass
 
@@ -347,7 +358,7 @@ class Emitter(object):
         raise ValueError("No emitters found for type %s" % format)
 
     @classmethod
-    def register(cls, name, klass, content_type='text/plain'):
+    def register(cls, name, klass, content_type="text/plain"):
         """
         Register an emitter.
 
@@ -397,8 +408,8 @@ class XMLEmitter(Emitter):
         return stream.getvalue()
 
 
-Emitter.register('xml', XMLEmitter, 'text/xml; charset=utf-8')
-Mimer.register(lambda *a: None, ('text/xml',))
+Emitter.register("xml", XMLEmitter, "text/xml; charset=utf-8")
+Mimer.register(lambda *a: None, ("text/xml",))
 
 
 class JSONEmitter(Emitter):
@@ -407,18 +418,20 @@ class JSONEmitter(Emitter):
     """
 
     def render(self, request):
-        cb = request.GET.get('callback', None)
-        seria = json.dumps(self.construct(), cls=DjangoJSONEncoder, ensure_ascii=False, indent=4)
+        cb = request.GET.get("callback", None)
+        seria = json.dumps(
+            self.construct(), cls=DjangoJSONEncoder, ensure_ascii=False, indent=4
+        )
 
         # Callback
         if cb and is_valid_jsonp_callback_value(cb):
-            return '%s(%s)' % (cb, seria)
+            return "%s(%s)" % (cb, seria)
 
         return seria
 
 
-Emitter.register('json', JSONEmitter, 'application/json; charset=utf-8')
-Mimer.register(json.loads, ('application/json',))
+Emitter.register("json", JSONEmitter, "application/json; charset=utf-8")
+Mimer.register(json.loads, ("application/json",))
 
 
 class YAMLEmitter(Emitter):
@@ -432,8 +445,8 @@ class YAMLEmitter(Emitter):
 
 
 if yaml:  # Only register yaml if it was import successfully.
-    Emitter.register('yaml', YAMLEmitter, 'application/x-yaml; charset=utf-8')
-    Mimer.register(lambda s: dict(yaml.load(s)), ('application/x-yaml',))
+    Emitter.register("yaml", YAMLEmitter, "application/x-yaml; charset=utf-8")
+    Mimer.register(lambda s: dict(yaml.load(s)), ("application/x-yaml",))
 
 
 class PickleEmitter(Emitter):
@@ -445,7 +458,7 @@ class PickleEmitter(Emitter):
         return pickle.dumps(self.construct())
 
 
-Emitter.register('pickle', PickleEmitter, 'application/python-pickle')
+Emitter.register("pickle", PickleEmitter, "application/python-pickle")
 
 """
 WARNING: Accepting arbitrary pickled data is a huge security concern.
@@ -464,7 +477,7 @@ class DjangoEmitter(Emitter):
     Emitter for the Django serialized format.
     """
 
-    def render(self, request, format='xml'):
+    def render(self, request, format="xml"):
         if isinstance(self.data, HttpResponse):
             return self.data
         elif isinstance(self.data, (int, str)):
@@ -475,4 +488,4 @@ class DjangoEmitter(Emitter):
         return response
 
 
-Emitter.register('django', DjangoEmitter, 'text/xml; charset=utf-8')
+Emitter.register("django", DjangoEmitter, "text/xml; charset=utf-8")

--- a/piston/tests_inspect_compat.py
+++ b/piston/tests_inspect_compat.py
@@ -1,0 +1,272 @@
+"""
+Tests for Python 3.12 inspect compatibility changes.
+
+inspect.getargspec() and inspect.formatargspec() were removed in Python 3.12.
+These tests verify that getfullargspec() and manual signature formatting
+work correctly in decorator.py, doc.py, and emitters.py.
+"""
+
+import inspect
+import unittest
+
+from piston.decorator import decorator, getinfo, new_wrapper, update_wrapper
+
+
+class GetinfoTest(unittest.TestCase):
+    """Tests for decorator.getinfo using inspect.getfullargspec."""
+
+    def test_simple_function(self):
+        def f(x, y):
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["name"], "f")
+        self.assertEqual(info["argnames"], ["x", "y"])
+        self.assertEqual(info["signature"], "x, y")
+        self.assertIsNone(info["defaults"])
+
+    def test_function_with_defaults(self):
+        def f(x, y=1, z=2):
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["name"], "f")
+        self.assertEqual(info["argnames"], ["x", "y", "z"])
+        self.assertEqual(info["defaults"], (1, 2))
+        self.assertEqual(info["signature"], "x, y, z")
+
+    def test_function_with_varargs(self):
+        def f(x, *args):
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["argnames"], ["x", "args"])
+        self.assertEqual(info["signature"], "x, *args")
+
+    def test_function_with_kwargs(self):
+        def f(x, **kwargs):
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["argnames"], ["x", "kwargs"])
+        self.assertEqual(info["signature"], "x, **kwargs")
+
+    def test_function_with_varargs_and_kwargs(self):
+        def f(self, x=1, y=2, *args, **kw):
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["argnames"], ["self", "x", "y", "args", "kw"])
+        self.assertEqual(info["defaults"], (1, 2))
+        self.assertEqual(info["signature"], "self, x, y, *args, **kw")
+
+    def test_function_with_no_args(self):
+        def f():
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["argnames"], [])
+        self.assertEqual(info["signature"], "")
+
+    def test_function_docstring(self):
+        def f(x):
+            """My docstring."""
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["doc"], "My docstring.")
+
+    def test_function_module(self):
+        def f(x):
+            pass
+
+        info = getinfo(f)
+        self.assertEqual(info["module"], __name__)
+
+
+class UpdateWrapperTest(unittest.TestCase):
+    """Tests for decorator.update_wrapper."""
+
+    def test_updates_name_and_doc(self):
+        def model(x, y):
+            """Model doc."""
+            pass
+
+        def wrapper(*args, **kwargs):
+            pass
+
+        result = update_wrapper(wrapper, model)
+        self.assertEqual(result.__name__, "model")
+        self.assertEqual(result.__doc__, "Model doc.")
+
+    def test_updates_defaults(self):
+        def model(x, y=5):
+            pass
+
+        def wrapper(*args, **kwargs):
+            pass
+
+        result = update_wrapper(wrapper, model)
+        self.assertEqual(result.__defaults__, (5,))
+
+
+class NewWrapperTest(unittest.TestCase):
+    """Tests for decorator.new_wrapper."""
+
+    def test_preserves_signature(self):
+        def model(a, b, c=3):
+            """Model function."""
+            pass
+
+        def wrapper(*args, **kwargs):
+            return args
+
+        result = new_wrapper(wrapper, model)
+        self.assertEqual(result.__name__, "model")
+        self.assertEqual(result.__doc__, "Model function.")
+        # The new wrapper should be callable with the model's signature
+        output = result(1, 2, 3)
+        self.assertEqual(output, (1, 2, 3))
+
+    def test_from_dict(self):
+        infodict = {
+            "name": "myfunc",
+            "argnames": ["x", "y"],
+            "signature": "x, y",
+            "defaults": None,
+            "doc": "A function.",
+            "module": __name__,
+            "dict": {},
+            "globals": {},
+            "closure": None,
+        }
+
+        def wrapper(*args, **kwargs):
+            return args
+
+        result = new_wrapper(wrapper, infodict)
+        self.assertEqual(result.__name__, "myfunc")
+        output = result(10, 20)
+        self.assertEqual(output, (10, 20))
+
+
+class DecoratorTest(unittest.TestCase):
+    """Tests for the decorator function using getfullargspec."""
+
+    def test_basic_decorator(self):
+        @decorator
+        def my_decorator(func, *args, **kw):
+            return func(*args, **kw)
+
+        @my_decorator
+        def add(x, y):
+            """Add two numbers."""
+            return x + y
+
+        self.assertEqual(add(2, 3), 5)
+        self.assertEqual(add.__name__, "add")
+        self.assertEqual(add.__doc__, "Add two numbers.")
+
+    def test_decorator_with_default_args(self):
+        @decorator
+        def my_decorator(func, *args, **kw):
+            return func(*args, **kw)
+
+        @my_decorator
+        def greet(name, greeting="Hello"):
+            return f"{greeting}, {name}!"
+
+        self.assertEqual(greet("World"), "Hello, World!")
+        self.assertEqual(greet("World", "Hi"), "Hi, World!")
+
+    def test_decorator_with_varargs(self):
+        @decorator
+        def my_decorator(func, *args, **kw):
+            return func(*args, **kw)
+
+        @my_decorator
+        def collect(*args, **kwargs):
+            return (args, kwargs)
+
+        self.assertEqual(collect(1, 2, a=3), ((1, 2), {"a": 3}))
+
+
+try:
+    from piston.doc import HandlerMethod
+
+    has_django = True
+except (ImportError, ModuleNotFoundError):
+    has_django = False
+
+
+@unittest.skipUnless(has_django, "Django is not installed")
+class HandlerMethodIterArgsTest(unittest.TestCase):
+    """Tests for doc.HandlerMethod.iter_args using getfullargspec."""
+
+    def test_iter_args_simple(self):
+        def read(self, request, pk):
+            pass
+
+        method = HandlerMethod(read)
+        args = list(method.iter_args())
+        self.assertEqual(args, [("pk", None)])
+
+    def test_iter_args_with_defaults(self):
+        def read(self, request, pk, format="json"):
+            pass
+
+        method = HandlerMethod(read)
+        args = list(method.iter_args())
+        self.assertEqual(args, [("pk", None), ("format", "json")])
+
+    def test_iter_args_skips_self_request_form(self):
+        def create(self, request, form):
+            pass
+
+        method = HandlerMethod(create)
+        args = list(method.iter_args())
+        self.assertEqual(args, [])
+
+    def test_signature_property(self):
+        def read(self, request, pk, format=None):
+            pass
+
+        method = HandlerMethod(read)
+        self.assertEqual(method.signature, "pk, format=<optional>")
+
+
+class EmittersGetFullArgSpecTest(unittest.TestCase):
+    """Tests for emitters.py usage of getfullargspec."""
+
+    def test_getfullargspec_no_args_function(self):
+        """Verify getfullargspec works for zero-arg functions (emitters check)."""
+
+        def no_args():
+            return 42
+
+        spec = inspect.getfullargspec(no_args)
+        self.assertEqual(spec[0], [])
+        self.assertEqual(len(spec[0]), 0)
+
+    def test_getfullargspec_one_arg_method(self):
+        """Verify getfullargspec works for single-arg methods (emitters check)."""
+
+        class MyModel:
+            def emittable(self):
+                return "data"
+
+        spec = inspect.getfullargspec(MyModel.emittable)
+        self.assertEqual(len(spec[0]), 1)
+
+    def test_getfullargspec_multi_arg_function(self):
+        """Verify getfullargspec identifies multi-arg functions correctly."""
+
+        def multi(a, b, c):
+            return a + b + c
+
+        spec = inspect.getfullargspec(multi)
+        self.assertEqual(len(spec[0]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`inspect.getargspec()` and `inspect.formatargspec()` were removed in Python 3.12.
This replaces them with `inspect.getfullargspec()` and manual signature formatting across `decorator.py`, `doc.py`, and `emitters.py`.