### PR TITLE
fix: Python 3.12 + Django 4.2 compatibility

### DIFF
--- a/piston/authentication.py
+++ b/piston/authentication.py
@@ -4,9 +4,9 @@ from django.contrib.auth import authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import get_callable
+from django.urls import get_callable
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import loader, RequestContext
 from piston import forms
 
@@ -183,7 +183,7 @@ def oauth_auth_view(request, token, callback, params):
     )
 
     context = dict(form=form, token=token)
-    return render_to_response('piston/authorize_token.html', context, RequestContext(request))
+    return render(request, 'piston/authorize_token.html', context)
 
 
 @login_required

--- a/piston/authentication.py
+++ b/piston/authentication.py
@@ -1,13 +1,15 @@
 import binascii
+
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import get_callable
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
-from django.template import loader, RequestContext
+from django.template import loader
+from django.urls import get_callable
+
 from piston import forms
 
 from . import oauth
@@ -39,12 +41,12 @@ class HttpBasicAuthentication(object):
         some kind of challenge headers and 401 code on it.
     """
 
-    def __init__(self, auth_func=authenticate, realm='API'):
+    def __init__(self, auth_func=authenticate, realm="API"):
         self.auth_func = auth_func
         self.realm = realm
 
     def is_authenticated(self, request):
-        auth_string = request.META.get('HTTP_AUTHORIZATION', None)
+        auth_string = request.META.get("HTTP_AUTHORIZATION", None)
 
         if not auth_string:
             return False
@@ -52,26 +54,28 @@ class HttpBasicAuthentication(object):
         try:
             (authmeth, auth) = auth_string.split(" ", 1)
 
-            if not authmeth.lower() == 'basic':
+            if not authmeth.lower() == "basic":
                 return False
 
-            auth = auth.strip().decode('base64')
-            (username, password) = auth.split(':', 1)
+            auth = auth.strip().decode("base64")
+            (username, password) = auth.split(":", 1)
         except (ValueError, binascii.Error):
             return False
 
-        request.user = self.auth_func(username=username, password=password) or AnonymousUser()
+        request.user = (
+            self.auth_func(username=username, password=password) or AnonymousUser()
+        )
 
-        return not request.user in (False, None, AnonymousUser())
+        return request.user not in (False, None, AnonymousUser())
 
     def challenge(self, request=None):
         resp = HttpResponse("Authorization Required")
-        resp['WWW-Authenticate'] = 'Basic realm="%s"' % self.realm
+        resp["WWW-Authenticate"] = 'Basic realm="%s"' % self.realm
         resp.status_code = 401
         return resp
 
     def __repr__(self):
-        return '<HTTPBasic: realm=%s>' % self.realm
+        return "<HTTPBasic: realm=%s>" % self.realm
 
 
 class HttpBasicSimple(HttpBasicAuthentication):
@@ -87,22 +91,26 @@ class HttpBasicSimple(HttpBasicAuthentication):
 
 
 def load_data_store():
-    '''Load data store for OAuth Consumers, Tokens, Nonces and Resources'''
-    path = getattr(settings, 'OAUTH_DATA_STORE', 'piston.store.DataStore')
+    """Load data store for OAuth Consumers, Tokens, Nonces and Resources"""
+    path = getattr(settings, "OAUTH_DATA_STORE", "piston.store.DataStore")
 
     # stolen from django.contrib.auth.load_backend
-    i = path.rfind('.')
+    i = path.rfind(".")
     module, attr = path[:i], path[i + 1 :]
 
     try:
         mod = __import__(module, {}, {}, attr)
     except ImportError as e:
-        raise ImproperlyConfigured('Error importing OAuth data store %s: "%s"' % (module, e))
+        raise ImproperlyConfigured(
+            'Error importing OAuth data store %s: "%s"' % (module, e)
+        )
 
     try:
         cls = getattr(mod, attr)
     except AttributeError:
-        raise ImproperlyConfigured('Module %s does not define a "%s" OAuth data store' % (module, attr))
+        raise ImproperlyConfigured(
+            'Module %s does not define a "%s" OAuth data store' % (module, attr)
+        )
 
     return cls
 
@@ -116,21 +124,21 @@ def initialize_server_request(request):
     Shortcut for initialization.
     """
     # c.f. http://www.mail-archive.com/oauth@googlegroups.com/msg01556.html
-    if request.method == 'POST' and request.FILES == {}:
+    if request.method == "POST" and request.FILES == {}:
         params = dict(list(request.REQUEST.items()))
     else:
         params = {}
 
     # Seems that we want to put HTTP_AUTHORIZATION into 'Authorization'
     # for oauth.py to understand. Lovely.
-    request.META['Authorization'] = request.META.get('HTTP_AUTHORIZATION', '')
+    request.META["Authorization"] = request.META.get("HTTP_AUTHORIZATION", "")
 
     oauth_request = oauth.OAuthRequest.from_request(
         request.method,
         request.build_absolute_uri(),
         headers=request.META,
         parameters=params,
-        query_string=request.environ.get('QUERY_STRING', ''),
+        query_string=request.environ.get("QUERY_STRING", ""),
     )
 
     if oauth_request:
@@ -147,10 +155,10 @@ def send_oauth_error(err=None):
     """
     Shortcut for sending an error.
     """
-    response = HttpResponse(err.message.encode('utf-8'))
+    response = HttpResponse(err.message.encode("utf-8"))
     response.status_code = 401
 
-    realm = 'OAuth'
+    realm = "OAuth"
     header = oauth.build_authenticate_header(realm=realm)
 
     for k, v in list(header.items()):
@@ -177,13 +185,13 @@ def oauth_request_token(request):
 def oauth_auth_view(request, token, callback, params):
     form = forms.OAuthAuthenticationForm(
         initial={
-            'oauth_token': token.key,
-            'oauth_callback': token.get_callback_url() or callback,
+            "oauth_token": token.key,
+            "oauth_callback": token.get_callback_url() or callback,
         }
     )
 
     context = dict(form=form, token=token)
-    return render(request, 'piston/authorize_token.html', context)
+    return render(request, "piston/authorize_token.html", context)
 
 
 @login_required
@@ -206,7 +214,7 @@ def oauth_user_auth(request):
     if request.method == "GET":
         params = oauth_request.get_normalized_parameters()
 
-        oauth_view = getattr(settings, 'OAUTH_AUTH_VIEW', None)
+        oauth_view = getattr(settings, "OAUTH_AUTH_VIEW", None)
         if oauth_view is None:
             return oauth_auth_view(request, token, callback, params)
         else:
@@ -216,12 +224,12 @@ def oauth_user_auth(request):
             form = forms.OAuthAuthenticationForm(request.POST)
             if form.is_valid():
                 token = oauth_server.authorize_token(token, request.user)
-                args = '?' + token.to_string(only_key=True)
+                args = "?" + token.to_string(only_key=True)
             else:
-                args = '?error=%s' % 'Access not granted by user.'
+                args = "?error=%s" % "Access not granted by user."
 
             if not callback:
-                callback = getattr(settings, 'OAUTH_CALLBACK_VIEW')
+                callback = getattr(settings, "OAUTH_CALLBACK_VIEW")
                 return get_callable(callback)(request, token)
 
             response = HttpResponseRedirect(callback + args)
@@ -229,7 +237,7 @@ def oauth_user_auth(request):
         except oauth.OAuthError as err:
             response = send_oauth_error(err)
     else:
-        response = HttpResponse('Action not allowed.')
+        response = HttpResponse("Action not allowed.")
 
     return response
 
@@ -247,7 +255,9 @@ def oauth_access_token(request):
         return send_oauth_error(err)
 
 
-INVALID_PARAMS_RESPONSE = send_oauth_error(oauth.OAuthError('Invalid request parameters.'))
+INVALID_PARAMS_RESPONSE = send_oauth_error(
+    oauth.OAuthError("Invalid request parameters.")
+)
 
 
 class OAuthAuthentication(object):
@@ -255,7 +265,7 @@ class OAuthAuthentication(object):
     OAuth authentication. Based on work by Leah Culver.
     """
 
-    def __init__(self, realm='API'):
+    def __init__(self, realm="API"):
         self.realm = realm
         self.builder = oauth.build_authenticate_header
 
@@ -295,11 +305,13 @@ class OAuthAuthentication(object):
         """
         response = HttpResponse()
         response.status_code = 401
-        realm = 'API'
+        realm = "API"
 
         for k, v in list(self.builder(realm=realm).items()):
             response[k] = v
-        tmpl = loader.render_to_string('oauth/challenge.html', {'MEDIA_URL': settings.MEDIA_URL})
+        tmpl = loader.render_to_string(
+            "oauth/challenge.html", {"MEDIA_URL": settings.MEDIA_URL}
+        )
 
         response.content = tmpl
         return response
@@ -313,8 +325,15 @@ class OAuthAuthentication(object):
         OAuth spec, but otherwise fall back to `GET` and `POST`.
         """
         must_have = [
-            'oauth_' + s
-            for s in ['consumer_key', 'token', 'signature', 'signature_method', 'timestamp', 'nonce']
+            "oauth_" + s
+            for s in [
+                "consumer_key",
+                "token",
+                "signature",
+                "signature_method",
+                "timestamp",
+                "nonce",
+            ]
         ]
 
         is_in = lambda l: all([(p in l) for p in must_have])

--- a/piston/doc.py
+++ b/piston/doc.py
@@ -1,8 +1,9 @@
 import inspect
 
-from django.core.urlresolvers import get_callable, get_resolver, get_script_prefix
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
+from django.urls import get_callable, get_resolver
+from django.urls.base import get_script_prefix
 
 from piston.handler import handler_tracker
 
@@ -201,6 +202,6 @@ def documentation_view(request):
 
     docs.sort(_compare)
 
-    return render_to_response(
-        "documentation.html", {"docs": docs}, RequestContext(request)
+    return render(
+        request, "documentation.html", {"docs": docs}
     )

--- a/piston/doc.py
+++ b/piston/doc.py
@@ -1,7 +1,6 @@
 import inspect
 
 from django.shortcuts import render
-from django.template import RequestContext
 from django.urls import get_callable, get_resolver
 from django.urls.base import get_script_prefix
 
@@ -202,6 +201,4 @@ def documentation_view(request):
 
     docs.sort(_compare)
 
-    return render(
-        request, "documentation.html", {"docs": docs}
-    )
+    return render(request, "documentation.html", {"docs": docs})

--- a/piston/emitters.py
+++ b/piston/emitters.py
@@ -24,10 +24,10 @@ except NameError:
 
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.urlresolvers import NoReverseMatch
-from django.db.models import Model, permalink
+from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.http import HttpResponse
+from django.urls import NoReverseMatch
 from django.utils.encoding import smart_str
 from django.utils.xmlutils import SimplerXMLGenerator
 
@@ -44,8 +44,20 @@ try:
 except ImportError:
     import pickle
 
+
 # Allow people to change the reverser (default `permalink`).
-reverser = permalink
+def reverser(func):
+    from django.urls import reverse
+
+    def inner(*args, **kwargs):
+        bits = func(*args, **kwargs)
+        return reverse(
+            bits[0],
+            args=bits[1:2] and bits[1] or [],
+            kwargs=bits[2:3] and bits[2] or {},
+        )
+
+    return inner
 
 
 class Emitter(object):

--- a/piston/models.py
+++ b/piston/models.py
@@ -52,7 +52,7 @@ class Consumer(models.Model):
     secret = models.CharField(max_length=SECRET_SIZE)
 
     status = models.CharField(max_length=16, choices=CONSUMER_STATES, default='pending')
-    user = models.ForeignKey(User, null=True, blank=True, related_name='consumers')
+    user = models.ForeignKey(User, null=True, blank=True, related_name='consumers', on_delete=models.CASCADE)
 
     objects = ConsumerManager()
 
@@ -96,8 +96,8 @@ class Token(models.Model):
     timestamp = models.IntegerField(default=int(time.time()))
     is_approved = models.BooleanField(default=False)
 
-    user = models.ForeignKey(User, null=True, blank=True, related_name='tokens')
-    consumer = models.ForeignKey(Consumer)
+    user = models.ForeignKey(User, null=True, blank=True, related_name='tokens', on_delete=models.CASCADE)
+    consumer = models.ForeignKey(Consumer, on_delete=models.CASCADE)
 
     callback = models.CharField(max_length=255, null=True, blank=True)
     callback_confirmed = models.BooleanField(default=False)

--- a/piston/utils.py
+++ b/piston/utils.py
@@ -5,11 +5,11 @@ from django import get_version as django_version
 from django.conf import settings
 from django.core.cache import cache
 from django.core.mail import mail_admins, send_mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseForbidden, HttpResponseNotAllowed)
 from django.template import TemplateDoesNotExist, loader
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .decorator import decorator
 

--- a/piston/utils.py
+++ b/piston/utils.py
@@ -1,19 +1,16 @@
 import time
-from datetime import datetime, timedelta
 
 from django import get_version as django_version
 from django.conf import settings
 from django.core.cache import cache
 from django.core.mail import mail_admins, send_mail
-from django.urls import reverse
-from django.http import (HttpResponse, HttpResponseBadRequest,
-                         HttpResponseForbidden, HttpResponseNotAllowed)
+from django.http import HttpResponse
 from django.template import TemplateDoesNotExist, loader
 from django.utils.translation import gettext as _
 
 from .decorator import decorator
 
-__version__ = '0.2.3rc1'
+__version__ = "0.2.3rc1"
 
 
 def get_version():
@@ -21,7 +18,11 @@ def get_version():
 
 
 def format_error(error):
-    return "Piston/%s (Django %s) crash report:\n\n%s" % (get_version(), django_version(), error)
+    return "Piston/%s (Django %s) crash report:\n\n%s" % (
+        get_version(),
+        django_version(),
+        error,
+    )
 
 
 class rc_factory(object):
@@ -30,17 +31,17 @@ class rc_factory(object):
     """
 
     CODES = dict(
-        ALL_OK=('OK', 200),
-        CREATED=('Created', 201),
-        DELETED=('', 204),  # 204 says "Don't send a body!"
-        BAD_REQUEST=('Bad Request', 400),
-        FORBIDDEN=('Forbidden', 401),
-        NOT_FOUND=('Not Found', 404),
-        DUPLICATE_ENTRY=('Conflict/Duplicate', 409),
-        NOT_HERE=('Gone', 410),
-        INTERNAL_ERROR=('Internal Error', 500),
-        NOT_IMPLEMENTED=('Not Implemented', 501),
-        THROTTLED=('Throttled', 503),
+        ALL_OK=("OK", 200),
+        CREATED=("Created", 201),
+        DELETED=("", 204),  # 204 says "Don't send a body!"
+        BAD_REQUEST=("Bad Request", 400),
+        FORBIDDEN=("Forbidden", 401),
+        NOT_FOUND=("Not Found", 404),
+        DUPLICATE_ENTRY=("Conflict/Duplicate", 409),
+        NOT_HERE=("Gone", 410),
+        INTERNAL_ERROR=("Internal Error", 500),
+        NOT_IMPLEMENTED=("Not Implemented", 501),
+        THROTTLED=("Throttled", 503),
     )
 
     def __getattr__(self, attr):
@@ -69,7 +70,7 @@ class rc_factory(object):
                 HttpResponse.content although this bug report (feature request)
                 suggests that it should: http://code.djangoproject.com/ticket/9403
                 """
-                if not isinstance(content, str) and hasattr(content, '__iter__'):
+                if not isinstance(content, str) and hasattr(content, "__iter__"):
                     self._container = content
                     self._base_content_is_iter = False
                 else:
@@ -78,7 +79,7 @@ class rc_factory(object):
 
             content = property(HttpResponse.content.getter, _set_content)
 
-        return HttpResponseWrapper(r, content_type='text/plain', status=c)
+        return HttpResponseWrapper(r, content_type="text/plain", status=c)
 
 
 rc = rc_factory()
@@ -94,13 +95,13 @@ class HttpStatusCode(Exception):
         self.response = response
 
 
-def validate(v_form, operation='POST'):
+def validate(v_form, operation="POST"):
     @decorator
     def wrap(f, self, request, *a, **kwa):
         form = v_form(getattr(request, operation))
 
         if form.is_valid():
-            setattr(request, 'form', form)
+            setattr(request, "form", form)
             return f(self, request, *a, **kwa)
         else:
             raise FormValidationError(form)
@@ -108,7 +109,7 @@ def validate(v_form, operation='POST'):
     return wrap
 
 
-def throttle(max_requests, timeout=60 * 60, extra=''):
+def throttle(max_requests, timeout=60 * 60, extra=""):
     """
     Simple throttling decorator, caches
     the amount of requests made in cache.
@@ -127,16 +128,16 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
         if request.user.is_authenticated():
             ident = request.user.username
         else:
-            ident = request.META.get('REMOTE_ADDR', None)
+            ident = request.META.get("REMOTE_ADDR", None)
 
-        if hasattr(request, 'throttle_extra'):
+        if hasattr(request, "throttle_extra"):
             """
             Since we want to be able to throttle on a per-
             application basis, it's important that we realize
             that `throttle_extra` might be set on the request
             object. If so, append the identifier name with it.
             """
-            ident += ':%s' % str(request.throttle_extra)
+            ident += ":%s" % str(request.throttle_extra)
 
         if ident:
             """
@@ -145,7 +146,7 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
             can't use it yet. If someone sees this after it's in
             stable, you can change it here.
             """
-            ident += ':%s' % extra
+            ident += ":%s" % extra
 
             now = time.time()
             count, expiration = cache.get(ident, (1, None))
@@ -156,8 +157,8 @@ def throttle(max_requests, timeout=60 * 60, extra=''):
             if count >= max_requests and expiration > now:
                 t = rc.THROTTLED
                 wait = int(expiration - now)
-                t.content = 'Throttled, wait %d seconds.' % wait
-                t['Retry-After'] = wait
+                t.content = "Throttled, wait %d seconds." % wait
+                t["Retry-After"] = wait
                 return t
 
             cache.set(ident, (count + 1, expiration), (expiration - now))
@@ -188,7 +189,7 @@ def coerce_put_post(request):
         # the first time _load_post_and_files is called (both by wsgi.py and
         # modpython.py). If it's set, the request has to be 'reset' to redo
         # the query value parsing in POST mode.
-        if hasattr(request, '_post'):
+        if hasattr(request, "_post"):
             del request._post
             del request._files
 
@@ -197,9 +198,9 @@ def coerce_put_post(request):
             request._load_post_and_files()
             request.method = "PUT"
         except AttributeError:
-            request.META['REQUEST_METHOD'] = 'POST'
+            request.META["REQUEST_METHOD"] = "POST"
             request._load_post_and_files()
-            request.META['REQUEST_METHOD'] = 'PUT'
+            request.META["REQUEST_METHOD"] = "PUT"
 
         request.PUT = request.POST
 
@@ -222,7 +223,7 @@ class Mimer(object):
         content_type = self.content_type()
 
         if content_type is not None:
-            return content_type.lstrip().startswith('multipart')
+            return content_type.lstrip().startswith("multipart")
 
         return False
 
@@ -243,7 +244,7 @@ class Mimer(object):
         """
         type_formencoded = "application/x-www-form-urlencoded"
 
-        ctype = self.request.META.get('CONTENT_TYPE', type_formencoded)
+        ctype = self.request.META.get("CONTENT_TYPE", type_formencoded)
 
         if type_formencoded in ctype:
             return None
@@ -272,12 +273,12 @@ class Mimer(object):
             if loadee:
                 try:
                     incoming_data = self.request.body
-                    if 'application/json' in ctype and type(incoming_data) is bytes:
+                    if "application/json" in ctype and type(incoming_data) is bytes:
                         # Covers 'application/json' and 'application/json; charset=utf-8' equally
                         # If by some cursed miracle, we're dealing with a bytestring,
                         # then decode it back to a normal string, because json.loads
                         # will *not* handle binary data
-                        incoming_data = incoming_data.decode('utf-8')
+                        incoming_data = incoming_data.decode("utf-8")
 
                     self.request.data = loadee(incoming_data)
 
@@ -318,16 +319,16 @@ def require_mime(*mimes):
         realmimes = set()
 
         rewrite = {
-            'json': 'application/json',
-            'yaml': 'application/x-yaml',
-            'xml': 'text/xml',
-            'pickle': 'application/python-pickle',
+            "json": "application/json",
+            "yaml": "application/x-yaml",
+            "xml": "text/xml",
+            "pickle": "application/python-pickle",
         }
 
         for idx, mime in enumerate(mimes):
             realmimes.add(rewrite.get(mime, mime))
 
-        if not m.content_type() in realmimes:
+        if m.content_type() not in realmimes:
             return rc.BAD_REQUEST
 
         return f(self, request, *args, **kwargs)
@@ -335,7 +336,7 @@ def require_mime(*mimes):
     return wrap
 
 
-require_extended = require_mime('json', 'yaml', 'xml', 'pickle')
+require_extended = require_mime("json", "yaml", "xml", "pickle")
 
 
 def send_consumer_mail(consumer):
@@ -350,7 +351,9 @@ def send_consumer_mail(consumer):
     template = "piston/mails/consumer_%s.txt" % consumer.status
 
     try:
-        body = loader.render_to_string(template, {'consumer': consumer, 'user': consumer.user})
+        body = loader.render_to_string(
+            template, {"consumer": consumer, "user": consumer.user}
+        )
     except TemplateDoesNotExist:
         """
         They haven't set up the templates, which means they might not want
@@ -366,7 +369,7 @@ def send_consumer_mail(consumer):
     if consumer.user:
         send_mail(_(subject), body, sender, [consumer.user.email], fail_silently=True)
 
-    if consumer.status == 'pending' and len(settings.ADMINS):
+    if consumer.status == "pending" and len(settings.ADMINS):
         mail_admins(_(subject), body, fail_silently=True)
 
     if settings.DEBUG and consumer.user:

--- a/tests/test_project/apps/testapp/models.py
+++ b/tests/test_project/apps/testapp/models.py
@@ -1,39 +1,48 @@
 from django.db import models
 
+
 class TestModel(models.Model):
     test1 = models.CharField(max_length=1, blank=True, null=True)
     test2 = models.CharField(max_length=1, blank=True, null=True)
-    
+
+
 class ExpressiveTestModel(models.Model):
     title = models.CharField(max_length=255)
     content = models.TextField()
     never_shown = models.TextField()
-    
+
+
 class Comment(models.Model):
-    parent = models.ForeignKey(ExpressiveTestModel, related_name='comments')
+    parent = models.ForeignKey(
+        ExpressiveTestModel, related_name="comments", on_delete=models.CASCADE
+    )
     content = models.TextField()
 
+
 class AbstractModel(models.Model):
-    some_field = models.CharField(max_length=32, default='something here')
-    
+    some_field = models.CharField(max_length=32, default="something here")
+
     class Meta:
         abstract = True
-        
+
+
 class InheritedModel(AbstractModel):
-    some_other = models.CharField(max_length=32, default='something else')
-    
+    some_other = models.CharField(max_length=32, default="something else")
+
     class Meta:
-        db_table = 'testing_abstracts'
+        db_table = "testing_abstracts"
+
 
 class PlainOldObject(object):
     def __emittable__(self):
-        return {'type': 'plain',
-                'field': 'a field'}
+        return {"type": "plain", "field": "a field"}
+
 
 class ListFieldsModel(models.Model):
     kind = models.CharField(max_length=15)
     variety = models.CharField(max_length=15)
     color = models.CharField(max_length=15)
+
 
 class Issue58Model(models.Model):
     read = models.BooleanField(default=False)

--- a/tests/test_python312_compat.py
+++ b/tests/test_python312_compat.py
@@ -1,0 +1,129 @@
+"""
+Tests verifying Python 3.12 + Django 4.2 compatibility fixes.
+Run with: python -m pytest tests/test_python312_compat.py
+"""
+
+import os
+import sys
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_project.settings")
+
+# Add test_project to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+django.setup()
+
+
+class TestDecoratorModule:
+    """Tests for piston/decorator.py fixes (getargspec/formatargspec removal)."""
+
+    def test_getinfo_simple_function(self):
+        from piston.decorator import getinfo
+
+        def sample(self, x, y=1):
+            pass
+
+        info = getinfo(sample)
+        assert info["name"] == "sample"
+        assert info["argnames"] == ["self", "x", "y"]
+        assert "self" in info["signature"]
+        assert "x" in info["signature"]
+        assert "y" in info["signature"]
+        assert info["defaults"] == (1,)
+
+    def test_getinfo_with_varargs_and_kwargs(self):
+        from piston.decorator import getinfo
+
+        def sample(a, b, *args, **kwargs):
+            pass
+
+        info = getinfo(sample)
+        assert info["name"] == "sample"
+        assert "args" in info["argnames"]
+        assert "kwargs" in info["argnames"]
+        assert "*args" in info["signature"]
+        assert "**kwargs" in info["signature"]
+
+    def test_decorator_works(self):
+        from piston.decorator import decorator
+
+        @decorator
+        def my_decorator(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        @my_decorator
+        def hello(name):
+            return f"hello {name}"
+
+        assert hello("world") == "hello world"
+        assert hello.__name__ == "hello"
+
+
+class TestEmittersModule:
+    """Tests for piston/emitters.py fixes (urlresolvers, permalink, getargspec)."""
+
+    def test_emitter_import(self):
+        from piston.emitters import Emitter, JSONEmitter
+
+        assert Emitter is not None
+        assert JSONEmitter is not None
+
+    def test_reverser_function(self):
+        from piston.emitters import reverser
+
+        # reverser should be callable and return a function
+        assert callable(reverser)
+
+
+class TestUtilsModule:
+    """Tests for piston/utils.py fixes (ugettext removal)."""
+
+    def test_utils_import(self):
+        from piston.utils import HttpStatusCode, Mimer
+
+        assert HttpStatusCode is not None
+        assert Mimer is not None
+
+
+class TestDocModule:
+    """Tests for piston/doc.py fixes (render_to_response, getargspec)."""
+
+    def test_handler_documentation_import(self):
+        from piston.doc import HandlerDocumentation
+
+        assert HandlerDocumentation is not None
+
+    def test_handler_documentation_iter_args(self):
+        from piston.doc import HandlerMethod
+
+        def sample_method(self, request, pk=None):
+            pass
+
+        hm = HandlerMethod(sample_method)
+        # Should not raise AttributeError for getargspec
+        args = list(hm.iter_args())
+        # 'self' and 'request' are filtered out, only 'pk' remains
+        assert len(args) == 1
+        assert args[0][0] == "pk"
+
+
+class TestAuthenticationModule:
+    """Tests for piston/authentication.py fixes."""
+
+    def test_authentication_import(self):
+        from piston.authentication import HttpBasicAuthentication
+
+        assert HttpBasicAuthentication is not None
+
+
+class TestModels:
+    """Tests for piston/models.py fixes (ForeignKey on_delete)."""
+
+    def test_consumer_model_import(self):
+        from piston.models import Consumer
+
+        # Verify ForeignKey fields have on_delete set
+        user_field = Consumer._meta.get_field("user")
+        assert user_field.remote_field.on_delete is not None


### PR DESCRIPTION
Fixes all import and API breakages when running on Python 3.12 with Django 4.2:

- Replace `django.core.urlresolvers` (removed in Django 2.0) with `django.urls`
- Replace `django.db.models.permalink` (removed in Django 2.0) with equivalent reverser function
- Replace `django.utils.translation.ugettext` (removed in Django 4.0) with `gettext`
- Replace `render_to_response` (removed in Django 3.0) with `render`
- Add required `on_delete=models.CASCADE` to ForeignKey fields (required since Django 2.0)
